### PR TITLE
Unified function naming rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ int main(int argc, char** argv) {
 #endif
   SocketAddr addr("0.0.0.0", 8070, false);
   TcpServer server(addr, false);
-  server.set_connection_callback(std::bind(OnConnection, _1));
-  server.set_read_callback(std::bind(OnMessage, _1, _2));
+  server.SetConnectionCallback(std::bind(OnConnection, _1));
+  server.SetReadCallback(std::bind(OnMessage, _1, _2));
   server.Start();
 #ifdef _MSC_VER
   WSACleanup();

--- a/examples/http/HttpCodec.cpp
+++ b/examples/http/HttpCodec.cpp
@@ -244,7 +244,7 @@ bool HttpResponse::PrepareMessage() {
 HttpCodec::HttpCodec(bool send_file)
     : send_file_(send_file) {}
 
-void HttpCodec::set_client_message_callback(
+void HttpCodec::SetClientMessageCallback(
     const HttpCodecMessageCallback& callback) {
   server_callback_ = callback;
 }

--- a/examples/http/HttpCodec.h
+++ b/examples/http/HttpCodec.h
@@ -62,7 +62,7 @@ class HttpCodec {
  public:
   HttpCodec(bool send_file = true);
   void OnClientMessage(const ConnectionPtr& conn, Buffer* buffer);
-  void set_client_message_callback(const HttpCodecMessageCallback& callback);
+  void SetClientMessageCallback(const HttpCodecMessageCallback& callback);
   void ParseRequest();
   void ParseResponse();
 

--- a/examples/http/HttpServer.cpp
+++ b/examples/http/HttpServer.cpp
@@ -14,7 +14,7 @@ HttpServer::HttpServer(const SocketAddr& addr, const char* cert_path,
       codec_(new HttpCodec(cert_path == nullptr || key_path == nullptr)) {
   codec_->set_client_message_callback(
       std::bind(&HttpServer::OnMessage, this, _1, _2));
-  set_read_callback(std::bind(&HttpCodec::OnClientMessage, codec_, _1, _2));
+  SetReadCallback(std::bind(&HttpCodec::OnClientMessage, codec_, _1, _2));
 }
 
 HttpServer::~HttpServer() { delete codec_; }

--- a/examples/http/HttpServer.cpp
+++ b/examples/http/HttpServer.cpp
@@ -12,7 +12,7 @@ HttpServer::HttpServer(const SocketAddr& addr, const char* cert_path,
                        const char* key_path)
     : TcpServer(addr, true, cert_path, key_path),
       codec_(new HttpCodec(cert_path == nullptr || key_path == nullptr)) {
-  codec_->set_client_message_callback(
+  codec_->SetClientMessageCallback(
       std::bind(&HttpServer::OnMessage, this, _1, _2));
   SetReadCallback(std::bind(&HttpCodec::OnClientMessage, codec_, _1, _2));
 }

--- a/ladder/include/Acceptor.h
+++ b/ladder/include/Acceptor.h
@@ -24,7 +24,7 @@ class Acceptor {
   Acceptor& operator=(const Acceptor&) = delete;
   ~Acceptor();
   void Init();
-  void set_new_connection_callback(const NewConnectionCallback& callback);
+  void SetNewConnectionCallback(const NewConnectionCallback& callback);
 
  private:
 #ifdef LADDER_OS_WINDOWS

--- a/ladder/include/Channel.h
+++ b/ladder/include/Channel.h
@@ -35,7 +35,7 @@ class LADDER_API Channel {
 #else
   Channel(EventLoopPtr loop, int fd);
   void HandleEvents();
-  void set_revents(uint32_t events);
+  void SetRevents(uint32_t events);
   uint32_t events() const;
   EventLoopPtr loop() const;
   void RemoveFromLoop();
@@ -44,9 +44,9 @@ class LADDER_API Channel {
   int fd() const;
   void EnableWrite(bool enable = true);
   void SetReadCallback(const EventCallback& callback);
-  void set_write_callback(const EventCallback& callback);
-  void set_close_callback(const std::function<void()>& callback);
-  void set_error_callback(const std::function<void()>& callback);
+  void SetWriteCallback(const EventCallback& callback);
+  void SetCloseCallback(const std::function<void()>& callback);
+  void SetErrorCallback(const std::function<void()>& callback);
 
 #ifdef LADDER_OS_LINUX
   void UpdateToLoop(int op = EPOLL_CTL_ADD);

--- a/ladder/include/Channel.h
+++ b/ladder/include/Channel.h
@@ -43,7 +43,7 @@ class LADDER_API Channel {
   ~Channel();
   int fd() const;
   void EnableWrite(bool enable = true);
-  void set_read_callback(const EventCallback& callback);
+  void SetReadCallback(const EventCallback& callback);
   void set_write_callback(const EventCallback& callback);
   void set_close_callback(const std::function<void()>& callback);
   void set_error_callback(const std::function<void()>& callback);

--- a/ladder/include/Connection.h
+++ b/ladder/include/Connection.h
@@ -39,8 +39,8 @@ class LADDER_API Connection : public std::enable_shared_from_this<Connection> {
   void SendFile(std::string&& header, const std::string& filename = "");
   void OnCloseCallback();
   void SetReadCallback(const ReadEvtCallback& callback);
-  void set_write_callback(const WriteEvtCallback& callback);
-  void set_close_callback(const ConnectCloseCallback& callback);
+  void SetWriteCallback(const WriteEvtCallback& callback);
+  void SetCloseCallback(const ConnectCloseCallback& callback);
   ChannelPtr channel() const;
 
  protected:

--- a/ladder/include/Connection.h
+++ b/ladder/include/Connection.h
@@ -38,7 +38,7 @@ class LADDER_API Connection : public std::enable_shared_from_this<Connection> {
   void Close();
   void SendFile(std::string&& header, const std::string& filename = "");
   void OnCloseCallback();
-  void set_read_callback(const ReadEvtCallback& callback);
+  void SetReadCallback(const ReadEvtCallback& callback);
   void set_write_callback(const WriteEvtCallback& callback);
   void set_close_callback(const ConnectCloseCallback& callback);
   ChannelPtr channel() const;

--- a/ladder/include/EventLoop.h
+++ b/ladder/include/EventLoop.h
@@ -35,7 +35,7 @@ class LADDER_API EventLoop {
   void StopLoop();
   void QueueInLoop(std::function<void()>&& task);
 #ifdef LADDER_OS_UNIX
-  void set_wakeup_callback(const std::function<void()>& callback);
+  void SetWakeupCallback(const std::function<void()>& callback);
 #endif
   // TODO: wake up poller for urgent tasks
 #ifdef LADDER_OS_FREEBSD

--- a/ladder/include/EventPoller.h
+++ b/ladder/include/EventPoller.h
@@ -27,7 +27,7 @@ class Pipe {
   ~Pipe();
   void Wakeup();
   Channel* channel() const;
-  void set_wakeup_callback(const std::function<void()>& callback);
+  void SetWakeupCallback(const std::function<void()>& callback);
 
  private:
   void ReadCallback();
@@ -50,7 +50,7 @@ class EventPoller {
   void RemoveChannel(int fd);
 #ifdef LADDER_OS_UNIX
   void Wakeup();
-  void set_wakeup_callback(const std::function<void()>& callback);
+  void SetWakeupCallback(const std::function<void()>& callback);
 #endif
 
  private:

--- a/ladder/include/TcpServer.h
+++ b/ladder/include/TcpServer.h
@@ -24,9 +24,9 @@ class LADDER_API TcpServer {
   TcpServer& operator=(const TcpServer&) = delete;
   ~TcpServer();
   void Start();
-  void set_read_callback(const ReadEvtCallback& callback);
+  void SetReadCallback(const ReadEvtCallback& callback);
   void set_write_callback(const WriteEvtCallback& callback);
-  void set_connection_callback(const ConnectionEvtCallback& callback);
+  void SetConnectionCallback(const ConnectionEvtCallback& callback);
 #ifndef LADDER_OS_WINDOWS
   EventLoopPtr loop() const;
 #endif

--- a/ladder/include/TcpServer.h
+++ b/ladder/include/TcpServer.h
@@ -25,7 +25,7 @@ class LADDER_API TcpServer {
   ~TcpServer();
   void Start();
   void SetReadCallback(const ReadEvtCallback& callback);
-  void set_write_callback(const WriteEvtCallback& callback);
+  void SetWriteCallback(const WriteEvtCallback& callback);
   void SetConnectionCallback(const ConnectionEvtCallback& callback);
 #ifndef LADDER_OS_WINDOWS
   EventLoopPtr loop() const;

--- a/ladder/src/Acceptor.cpp
+++ b/ladder/src/Acceptor.cpp
@@ -88,7 +88,7 @@ void Acceptor::HandleAcceptCallback() {
 
 #endif
 
-void Acceptor::set_new_connection_callback(const NewConnectionCallback& callback) {
+void Acceptor::SetNewConnectionCallback(const NewConnectionCallback& callback) {
   new_connection_callback_ = callback;
 }
 

--- a/ladder/src/Acceptor.cpp
+++ b/ladder/src/Acceptor.cpp
@@ -19,7 +19,7 @@ static thread_local LPFN_ACCEPTEX fn_acceptex = nullptr;
 
 Acceptor::Acceptor(const ChannelPtr& channel, bool ipv6)
     : channel_(channel), ipv6_(ipv6) {
-  channel->set_read_callback(
+  channel->SetReadCallback(
       std::bind(&Acceptor::HandleAcceptCallback, this, std::placeholders::_1));
   accept_buffer_ = new char[kMaxIocpRecvSize];
   cur_accept_fd_ = 0;
@@ -68,7 +68,7 @@ void Acceptor::HandleAcceptCallback(int io_size) {
 #else
 Acceptor::Acceptor(const ChannelPtr& channel, bool ipv6)
     : channel_(channel), ipv6_(ipv6) {
-  channel->set_read_callback(std::bind(&Acceptor::HandleAcceptCallback, this));
+  channel->SetReadCallback(std::bind(&Acceptor::HandleAcceptCallback, this));
 }
 
 Acceptor::~Acceptor() {}

--- a/ladder/src/Channel.cpp
+++ b/ladder/src/Channel.cpp
@@ -37,15 +37,15 @@ void Channel::SetReadCallback(const EventCallback& callback) {
   read_callback_ = callback;
 }
 
-void Channel::set_write_callback(const EventCallback& callback) {
+void Channel::SetWriteCallback(const EventCallback& callback) {
   write_callback_ = callback;
 }
 
-void Channel::set_close_callback(const std::function<void()>& callback) {
+void Channel::SetCloseCallback(const std::function<void()>& callback) {
   close_callback_ = callback;
 }
 
-void Channel::set_error_callback(const std::function<void()>& callback) {
+void Channel::SetErrorCallback(const std::function<void()>& callback) {
   error_callback_ = callback;
 }
 
@@ -66,7 +66,7 @@ void Channel::HandleEvents(int evts, int io_size) {
 
 #else
 
-void Channel::set_revents(uint32_t events) { revents_ |= events; }
+void Channel::SetRevents(uint32_t events) { revents_ |= events; }
 
 uint32_t Channel::events() const { return events_; }
 

--- a/ladder/src/Channel.cpp
+++ b/ladder/src/Channel.cpp
@@ -33,7 +33,7 @@ Channel::Channel(EventLoopPtr loop, int fd)
 
 Channel::~Channel() { LOGF_DEBUG("Destroying channel fd = %d", fd_); }
 
-void Channel::set_read_callback(const EventCallback& callback) {
+void Channel::SetReadCallback(const EventCallback& callback) {
   read_callback_ = callback;
 }
 

--- a/ladder/src/Connection.cpp
+++ b/ladder/src/Connection.cpp
@@ -65,12 +65,12 @@ Connection::~Connection() {
 
 void Connection::SetChannelCallbacks() {
 #ifdef LADDER_OS_WINDOWS
-  channel_->set_read_callback(
+  channel_->SetReadCallback(
       std::bind(&Connection::OnReadCallback, this, std::placeholders::_1));
   channel_->set_write_callback(
       std::bind(&Connection::OnWriteCallback, this, std::placeholders::_1));
 #else
-  channel_->set_read_callback(std::bind(&Connection::OnReadCallback, this));
+  channel_->SetReadCallback(std::bind(&Connection::OnReadCallback, this));
   channel_->set_write_callback(std::bind(&Connection::OnWriteCallback, this));
 #endif
   channel_->set_close_callback(std::bind(&Connection::OnCloseCallback, this));
@@ -106,7 +106,7 @@ void Connection::OnCloseCallback() {
   }
 }
 
-void Connection::set_read_callback(const ReadEvtCallback& callback) {
+void Connection::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 

--- a/ladder/src/Connection.cpp
+++ b/ladder/src/Connection.cpp
@@ -67,14 +67,14 @@ void Connection::SetChannelCallbacks() {
 #ifdef LADDER_OS_WINDOWS
   channel_->SetReadCallback(
       std::bind(&Connection::OnReadCallback, this, std::placeholders::_1));
-  channel_->set_write_callback(
+  channel_->SetWriteCallback(
       std::bind(&Connection::OnWriteCallback, this, std::placeholders::_1));
 #else
   channel_->SetReadCallback(std::bind(&Connection::OnReadCallback, this));
-  channel_->set_write_callback(std::bind(&Connection::OnWriteCallback, this));
+  channel_->SetWriteCallback(std::bind(&Connection::OnWriteCallback, this));
 #endif
-  channel_->set_close_callback(std::bind(&Connection::OnCloseCallback, this));
-  channel_->set_error_callback(std::bind(&Connection::OnCloseCallback, this));
+  channel_->SetCloseCallback(std::bind(&Connection::OnCloseCallback, this));
+  channel_->SetErrorCallback(std::bind(&Connection::OnCloseCallback, this));
 }
 
 void Connection::Send(const std::string& buf) {
@@ -110,11 +110,11 @@ void Connection::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 
-void Connection::set_write_callback(const WriteEvtCallback& callback) {
+void Connection::SetWriteCallback(const WriteEvtCallback& callback) {
   write_callback_ = callback;
 }
 
-void Connection::set_close_callback(const ConnectCloseCallback& callback) {
+void Connection::SetCloseCallback(const ConnectCloseCallback& callback) {
   close_callback_ = callback;
 }
 

--- a/ladder/src/EventLoop.cpp
+++ b/ladder/src/EventLoop.cpp
@@ -81,8 +81,8 @@ void EventLoop::QueueInLoop(std::function<void()>&& task) {
 }
 
 #ifdef LADDER_OS_UNIX
-void EventLoop::set_wakeup_callback(const std::function<void()>& callback) {
-  poller_->set_wakeup_callback(callback);
+void EventLoop::SetWakeupCallback(const std::function<void()>& callback) {
+  poller_->SetWakeupCallback(callback);
 }
 #endif
 

--- a/ladder/src/EventPoller.cpp
+++ b/ladder/src/EventPoller.cpp
@@ -51,7 +51,7 @@ void EventPoller::Poll(std::vector<Channel*>& active_channels) {
     uint32_t evt = 0;
     evt = poll_evts[i].events;
     Channel* channel = reinterpret_cast<Channel*>(poll_evts[i].data.ptr);
-    channel->set_revents(evt);
+    channel->SetRevents(evt);
     active_channels.emplace_back(channel);
   }
 }
@@ -143,7 +143,7 @@ void EventPoller::Poll(std::vector<Channel*>& active_channels) {
     short flt = poll_evts[i].filter;
     Channel* channel = reinterpret_cast<Channel*>(poll_evts[i].udata);
     if (poll_evts[i].flags & EV_ERROR) {
-      channel->set_revents(kPollEvent::kPollErr);
+      channel->SetRevents(kPollEvent::kPollErr);
       continue;
     }
 
@@ -151,7 +151,7 @@ void EventPoller::Poll(std::vector<Channel*>& active_channels) {
     if (iter != flt_2_stat_.end()) {
       evt = iter->second;
     }
-    channel->set_revents(evt);
+    channel->SetRevents(evt);
     active_channels.emplace_back(channel);
   }
 }
@@ -215,8 +215,8 @@ EventPoller::~EventPoller() {}
 
 void EventPoller::Wakeup() { pipe_->Wakeup(); }
 
-void EventPoller::set_wakeup_callback(const std::function<void()>& callback) {
-  pipe_->set_wakeup_callback(callback);
+void EventPoller::SetWakeupCallback(const std::function<void()>& callback) {
+  pipe_->SetWakeupCallback(callback);
 }
 
 
@@ -242,7 +242,7 @@ void Pipe::Wakeup() {
 
 Channel* Pipe::channel() const { return channel_; }
 
-void Pipe::set_wakeup_callback(const std::function<void()>& callback) {
+void Pipe::SetWakeupCallback(const std::function<void()>& callback) {
   wakeup_callback_ = callback;
 }
 

--- a/ladder/src/EventPoller.cpp
+++ b/ladder/src/EventPoller.cpp
@@ -226,7 +226,7 @@ Pipe::Pipe() {
     EXIT("pipe2");
   }
   channel_ = new Channel(nullptr, fd_[0]);
-  channel_->set_read_callback(std::bind(&Pipe::ReadCallback, this));
+  channel_->SetReadCallback(std::bind(&Pipe::ReadCallback, this));
 }
 
 Pipe::~Pipe() {

--- a/ladder/src/TcpServer.cpp
+++ b/ladder/src/TcpServer.cpp
@@ -104,7 +104,7 @@ void TcpServer::Start() {
   loop_->StartLoop();
 }
 
-void TcpServer::set_read_callback(const ReadEvtCallback& callback) {
+void TcpServer::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 
@@ -112,7 +112,7 @@ void TcpServer::set_write_callback(const WriteEvtCallback& callback) {
   write_callback_ = callback;
 }
 
-void TcpServer::set_connection_callback(const ConnectionEvtCallback& callback) {
+void TcpServer::SetConnectionCallback(const ConnectionEvtCallback& callback) {
   connection_callback_ = callback;
 }
 
@@ -137,7 +137,7 @@ void TcpServer::OnNewConnection(int fd, const SocketAddr& addr) {
   else
     connection = std::make_shared<Connection>(loop, fd, send_file_);
 #endif
-  connection->set_read_callback(read_callback_);
+  connection->SetReadCallback(read_callback_);
   connection->set_write_callback(write_callback_);
   connection->set_close_callback(
       std::bind(&TcpServer::OnCloseConnectionCallback, this, fd));

--- a/ladder/src/TcpServer.cpp
+++ b/ladder/src/TcpServer.cpp
@@ -80,7 +80,7 @@ void TcpServer::Start() {
   iocp_port_ = UpdateIocpPort(NULL, channel_.get());
   loop_ = std::make_shared<EventLoop>(iocp_port_);
   acceptor_.reset(new Acceptor(channel_, addr_.ipv6()));
-  acceptor_->set_new_connection_callback(
+  acceptor_->SetNewConnectionCallback(
       std::bind(&TcpServer::OnNewConnection,
                 this,
                 std::placeholders::_1,
@@ -95,7 +95,7 @@ void TcpServer::Start() {
   channel_.reset(new Channel(loop_, fd));
   channel_->UpdateToLoop();
   acceptor_.reset(new Acceptor(channel_, addr_.ipv6()));
-  acceptor_->set_new_connection_callback(
+  acceptor_->SetNewConnectionCallback(
       std::bind(&TcpServer::OnNewConnectionCallback, this,
                 std::placeholders::_1, std::placeholders::_2));
   loop_threads_.reset(new EventLoopThreadPool(loop_thread_num_));
@@ -108,7 +108,7 @@ void TcpServer::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 
-void TcpServer::set_write_callback(const WriteEvtCallback& callback) {
+void TcpServer::SetWriteCallback(const WriteEvtCallback& callback) {
   write_callback_ = callback;
 }
 
@@ -138,8 +138,8 @@ void TcpServer::OnNewConnection(int fd, const SocketAddr& addr) {
     connection = std::make_shared<Connection>(loop, fd, send_file_);
 #endif
   connection->SetReadCallback(read_callback_);
-  connection->set_write_callback(write_callback_);
-  connection->set_close_callback(
+  connection->SetWriteCallback(write_callback_);
+  connection->SetCloseCallback(
       std::bind(&TcpServer::OnCloseConnectionCallback, this, fd));
 #ifdef LADDER_OS_WINDOWS
   connection->Init(iocp_port_, buffer, io_size);

--- a/ladder_client/include/Connector.h
+++ b/ladder_client/include/Connector.h
@@ -24,7 +24,7 @@ class Connector {
   Connector& operator=(const Connector&) = delete;
   ~Connector();
   void SetConnectionCallback(const ConnectionCallback& callback);
-  void set_connection_failure_callback(const ConnectionFailureCallback& callback);
+  void SetConnectionFailureCallback(const ConnectionFailureCallback& callback);
   void Start();
 
  private:

--- a/ladder_client/include/Connector.h
+++ b/ladder_client/include/Connector.h
@@ -23,7 +23,7 @@ class Connector {
   Connector(const Connector&) = delete;
   Connector& operator=(const Connector&) = delete;
   ~Connector();
-  void set_connection_callback(const ConnectionCallback& callback);
+  void SetConnectionCallback(const ConnectionCallback& callback);
   void set_connection_failure_callback(const ConnectionFailureCallback& callback);
   void Start();
 

--- a/ladder_client/include/TcpClient.h
+++ b/ladder_client/include/TcpClient.h
@@ -34,9 +34,9 @@ class LADDER_API TcpClient {
 #endif
   void Disconnect();
 
-  void set_read_callback(const ReadEvtCallback& callback);
+  void SetReadCallback(const ReadEvtCallback& callback);
   void set_write_callback(const WriteEvtCallback& callback);
-  void set_connection_callback(const ConnectionEvtCallback& callback);
+  void SetConnectionCallback(const ConnectionEvtCallback& callback);
 
  private:
   void OnConnectionCallback(SocketAddr&&);

--- a/ladder_client/include/TcpClient.h
+++ b/ladder_client/include/TcpClient.h
@@ -35,7 +35,7 @@ class LADDER_API TcpClient {
   void Disconnect();
 
   void SetReadCallback(const ReadEvtCallback& callback);
-  void set_write_callback(const WriteEvtCallback& callback);
+  void SetWriteCallback(const WriteEvtCallback& callback);
   void SetConnectionCallback(const ConnectionEvtCallback& callback);
 
  private:

--- a/ladder_client/include/Timer.h
+++ b/ladder_client/include/Timer.h
@@ -24,8 +24,8 @@ class Timer {
   Timer(const EventLoopPtr& loop);
 #endif
   ~Timer();
-  void set_interval(uint64_t microseconds, bool periodic = false);
-  void set_timer_event_callback(const TimerEventCallback& callback);
+  void SetInterval(uint64_t microseconds, bool periodic = false);
+  void SetTimmerEventCallback(const TimerEventCallback& callback);
   uint64_t GetInterval() const;
   void OnTimer();
 

--- a/ladder_client/src/Connector.cpp
+++ b/ladder_client/src/Connector.cpp
@@ -22,7 +22,7 @@ Connector::Connector(const ChannelPtr& channel, int max_retry,
 #endif
       ipv6_(addr.ipv6()),
       addr_(addr) {
-  timer_->set_timer_event_callback(std::bind(&Connector::Start, this));
+  timer_->SetTimmerEventCallback(std::bind(&Connector::Start, this));
 }
 
 #ifdef LADDER_OS_WINDOWS
@@ -42,15 +42,15 @@ void Connector::SetConnectionCallback(const ConnectionCallback& callback) {
   connection_callback_ = callback;
 }
 
-void Connector::set_connection_failure_callback(
+void Connector::SetConnectionFailureCallback(
     const ConnectionFailureCallback& callback) {
   connection_failure_callback_ = callback;
 }
 
 void Connector::Start() {
-  channel_->set_write_callback(std::bind(&Connector::HandleConnect, this));
-  channel_->set_error_callback(std::bind(&Connector::Retry, this));
-  channel_->set_close_callback(std::bind(&Connector::Retry, this));
+  channel_->SetWriteCallback(std::bind(&Connector::HandleConnect, this));
+  channel_->SetErrorCallback(std::bind(&Connector::Retry, this));
+  channel_->SetCloseCallback(std::bind(&Connector::Retry, this));
   channel_->SetReadCallback(nullptr);
   channel_->EnableWrite(true);
   const sockaddr_t* sa = addr_.addr();
@@ -135,7 +135,7 @@ void Connector::Retry() {
     LOG_DEBUG("Connect failed. Trying again after " +
               std::to_string(retry_timeout_) + " ms.");
     // TODO: retry connect
-    timer_->set_interval(retry_timeout_ * 1000, false);
+    timer_->SetInterval(retry_timeout_ * 1000, false);
     retry_timeout_ <<= 1;
   } else {
     if (connection_failure_callback_) {

--- a/ladder_client/src/Connector.cpp
+++ b/ladder_client/src/Connector.cpp
@@ -38,7 +38,7 @@ Connector::~Connector() {}
 
 #endif
 
-void Connector::set_connection_callback(const ConnectionCallback& callback) {
+void Connector::SetConnectionCallback(const ConnectionCallback& callback) {
   connection_callback_ = callback;
 }
 
@@ -51,7 +51,7 @@ void Connector::Start() {
   channel_->set_write_callback(std::bind(&Connector::HandleConnect, this));
   channel_->set_error_callback(std::bind(&Connector::Retry, this));
   channel_->set_close_callback(std::bind(&Connector::Retry, this));
-  channel_->set_read_callback(nullptr);
+  channel_->SetReadCallback(nullptr);
   channel_->EnableWrite(true);
   const sockaddr_t* sa = addr_.addr();
 #ifdef LADDER_OS_WINDOWS

--- a/ladder_client/src/TcpClient.cpp
+++ b/ladder_client/src/TcpClient.cpp
@@ -60,7 +60,7 @@ void TcpClient::Connect() {
   else
     conn_.reset(new TlsConnection(fd, ssl_ctx_, false));
   conn_->SetReadCallback(read_callback_);
-  conn_->set_close_callback(
+  conn_->SetCloseCallback(
       std::bind(&TcpClient::OnCloseConnectionCallback, this, fd));
   /* ConnectEx requires the socket to be initially bound. */
   local_addr.Bind(conn_->channel()->fd());
@@ -72,14 +72,14 @@ void TcpClient::Connect() {
   else
     conn_.reset(new TlsConnection(loop_, fd, ssl_ctx_, false));
   conn_->SetReadCallback(read_callback_);
-  conn_->set_close_callback(
+  conn_->SetCloseCallback(
       std::bind(&TcpClient::OnCloseConnectionCallback, this, fd));
   connector_.reset(new Connector(conn_->channel(), max_retry_, target_addr_,
                                  retry_initial_timeout_));
 #endif
   connector_->SetConnectionCallback(
       std::bind(&TcpClient::OnConnectionCallback, this, std::placeholders::_1));
-  connector_->set_connection_failure_callback(
+  connector_->SetConnectionFailureCallback(
       std::bind(&TcpClient::OnConnectionFailureCallback, this));
   LOGF_INFO("Trying to establish connection to target. fd = %d", fd);
 #ifdef LADDER_OS_WINDOWS
@@ -107,7 +107,7 @@ void TcpClient::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 
-void TcpClient::set_write_callback(const WriteEvtCallback& callback) {
+void TcpClient::SetWriteCallback(const WriteEvtCallback& callback) {
   write_callback_ = callback;
 }
 

--- a/ladder_client/src/TcpClient.cpp
+++ b/ladder_client/src/TcpClient.cpp
@@ -59,7 +59,7 @@ void TcpClient::Connect() {
     conn_.reset(new Connection(fd));
   else
     conn_.reset(new TlsConnection(fd, ssl_ctx_, false));
-  conn_->set_read_callback(read_callback_);
+  conn_->SetReadCallback(read_callback_);
   conn_->set_close_callback(
       std::bind(&TcpClient::OnCloseConnectionCallback, this, fd));
   /* ConnectEx requires the socket to be initially bound. */
@@ -71,13 +71,13 @@ void TcpClient::Connect() {
     conn_.reset(new Connection(loop_, fd));
   else
     conn_.reset(new TlsConnection(loop_, fd, ssl_ctx_, false));
-  conn_->set_read_callback(read_callback_);
+  conn_->SetReadCallback(read_callback_);
   conn_->set_close_callback(
       std::bind(&TcpClient::OnCloseConnectionCallback, this, fd));
   connector_.reset(new Connector(conn_->channel(), max_retry_, target_addr_,
                                  retry_initial_timeout_));
 #endif
-  connector_->set_connection_callback(
+  connector_->SetConnectionCallback(
       std::bind(&TcpClient::OnConnectionCallback, this, std::placeholders::_1));
   connector_->set_connection_failure_callback(
       std::bind(&TcpClient::OnConnectionFailureCallback, this));
@@ -103,7 +103,7 @@ void TcpClient::Disconnect() {
   conn_->channel()->ShutDownWrite();
 }
 
-void TcpClient::set_read_callback(const ReadEvtCallback& callback) {
+void TcpClient::SetReadCallback(const ReadEvtCallback& callback) {
   read_callback_ = callback;
 }
 
@@ -111,7 +111,7 @@ void TcpClient::set_write_callback(const WriteEvtCallback& callback) {
   write_callback_ = callback;
 }
 
-void TcpClient::set_connection_callback(const ConnectionEvtCallback& callback) {
+void TcpClient::SetConnectionCallback(const ConnectionEvtCallback& callback) {
   connection_callback_ = callback;
 }
 

--- a/ladder_client/src/Timer.cpp
+++ b/ladder_client/src/Timer.cpp
@@ -68,11 +68,11 @@ Timer::Timer(const EventLoopPtr& loop)
   }
   timer_channel_ = std::make_shared<Channel>(loop, timer_fd_);
   timer_channel_->UpdateToLoop();
-  timer_channel_->set_read_callback(std::bind(&Timer::OnTimer, this));
+  timer_channel_->SetReadCallback(std::bind(&Timer::OnTimer, this));
 #elif defined(LADDER_OS_FREEBSD)
   timer_fd_ = 1;
   timer_channel_ = std::make_shared<Channel>(loop, timer_fd_);
-  timer_channel_->set_read_callback(std::bind(&Timer::OnTimer, this));
+  timer_channel_->SetReadCallback(std::bind(&Timer::OnTimer, this));
 #endif
 }
 

--- a/ladder_client/src/Timer.cpp
+++ b/ladder_client/src/Timer.cpp
@@ -40,7 +40,7 @@ Timer::~Timer() {
   CloseHandle(timer_queue_);
 }
 
-void Timer::set_interval(uint64_t interval, bool periodic) {
+void Timer::SetInterval(uint64_t interval, bool periodic) {
   uint64_t milliseconds = interval / 1000;
   if (!timer_) {
     if (!CreateTimerQueueTimer(&timer_, timer_queue_,
@@ -86,7 +86,7 @@ Timer::~Timer() {
 #endif
 }
 
-void Timer::set_interval(uint64_t interval, bool periodic) {
+void Timer::SetInterval(uint64_t interval, bool periodic) {
 #ifdef LADDER_OS_LINUX
   struct itimerspec value;
   bzero(&value, sizeof(value));
@@ -115,7 +115,7 @@ void Timer::set_interval(uint64_t interval, bool periodic) {
 
 #endif
 
-void Timer::set_timer_event_callback(const TimerEventCallback& callback) {
+void Timer::SetTimmerEventCallback(const TimerEventCallback& callback) {
   callback_ = callback;
 }
 

--- a/tests/event_poller/test_event_poller.cpp
+++ b/tests/event_poller/test_event_poller.cpp
@@ -16,7 +16,7 @@ void WakeupCallback() { LOG_INFO("wakeup callback"); }
 int main(int argc, char** argv) {
   Logger::create();
   EventLoop loop;
-  loop.set_wakeup_callback(WakeupCallback);
+  loop.SetWakeupCallback(WakeupCallback);
   std::thread th(&EventLoop::StartLoop, &loop);
 
   LOG_WARNING("First wakeup");

--- a/tests/file_server/test_file_server.cpp
+++ b/tests/file_server/test_file_server.cpp
@@ -27,8 +27,8 @@ int main(int argc, char** argv) {
   Logger::create("./test_file_server.log");
   SocketAddr addr("0.0.0.0", 8070, false);
   TcpServer server(addr, true);
-  server.set_connection_callback(std::bind(OnConnection, _1));
-  server.set_read_callback(std::bind(OnMessage, _1, _2));
+  server.SetConnectionCallback(std::bind(OnConnection, _1));
+  server.SetReadCallback(std::bind(OnMessage, _1, _2));
   server.Start();
   return 0;
 }

--- a/tests/proto_server/test_proto_server.cpp
+++ b/tests/proto_server/test_proto_server.cpp
@@ -26,7 +26,7 @@ static ProtobufCodec* p_codec = nullptr;
 void OnRawMessage(const ConnectionPtr& conn, Buffer* buffer) {
   std::string msg = buffer->ReadAll();
   LOG_INFO("Recv: " + msg);
-  conn->set_read_callback(
+  conn->SetReadCallback(
       std::bind(&ProtobufCodec::OnMessage, p_codec, _1, _2));
 
   ladder::TestMessage1 message;
@@ -85,10 +85,10 @@ int main(int argc, char** argv) {
 #ifdef LADDER_OS_WINDOWS
   // iocp server cannot send data on connection
   p_codec = &codec;
-  server.set_read_callback(std::bind(OnRawMessage, _1, _2));
+  server.SetReadCallback(std::bind(OnRawMessage, _1, _2));
 #else
-  server.set_connection_callback(std::bind(OnConnection, _1, codec));
-  server.set_read_callback(
+  server.SetConnectionCallback(std::bind(OnConnection, _1, codec));
+  server.SetReadCallback(
       std::bind(&ProtobufCodec::OnMessage, &codec, _1, _2));
 #endif
   server.Start();

--- a/tests/server/test_server.cpp
+++ b/tests/server/test_server.cpp
@@ -37,9 +37,9 @@ int main(int argc, char** argv) {
   SocketAddr addr("0.0.0.0", 8070, false);
   TcpServer server(addr, false);
 #ifndef _MSC_VER
-  server.set_connection_callback(std::bind(OnConnection, _1));
+  server.SetConnectionCallback(std::bind(OnConnection, _1));
 #endif
-  server.set_read_callback(std::bind(OnMessage, _1, _2));
+  server.SetReadCallback(std::bind(OnMessage, _1, _2));
   server.Start();
   return 0;
 }

--- a/tests/ssl_server/test_ssl_server.cpp
+++ b/tests/ssl_server/test_ssl_server.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
   SocketAddr addr("0.0.0.0", 8070, false);
   SslInit();
   TcpServer server(addr, false, argv[1], argv[2]);
-  server.set_read_callback(std::bind(OnMessage, _1, _2));
+  server.SetReadCallback(std::bind(OnMessage, _1, _2));
   server.Start();
   return EXIT_SUCCESS;
 }

--- a/tests_client/ssl_client/test_ssl_client.cpp
+++ b/tests_client/ssl_client/test_ssl_client.cpp
@@ -40,8 +40,8 @@ int main(int argc, char** argv) {
   EventLoopThread loop_thread;
   SslInit();
   TcpClient client(addr, loop_thread.loop(), 10, true);
-  client.set_connection_callback(std::bind(OnConnection, _1));
-  client.set_read_callback(std::bind(OnMessage, _1, _2));
+  client.SetConnectionCallback(std::bind(OnConnection, _1));
+  client.SetReadCallback(std::bind(OnMessage, _1, _2));
 #ifdef _MSC_VER
   SocketAddr local_addr("127.0.0.1", 31312, false);
   client.Connect(local_addr);

--- a/tests_client/tcp_client/test_tcp_client.cpp
+++ b/tests_client/tcp_client/test_tcp_client.cpp
@@ -40,9 +40,9 @@ int main(int argc, char** argv) {
   SocketAddr addr("127.0.0.1", 8070, false);
   EventLoopThread loop_thread;
   TcpClient client(addr, loop_thread.loop(), 10);
-  client.set_read_callback(std::bind(OnMessage, _1, _2));
+  client.SetReadCallback(std::bind(OnMessage, _1, _2));
+  client.SetConnectionCallback(std::bind(OnConnection, _1));
 #ifdef _MSC_VER
-  client.set_connection_callback(std::bind(OnConnection, _1));
   SocketAddr local_addr("127.0.0.1", 31311, false);
   client.Connect(local_addr);
 #else

--- a/tests_client/timer/test_timer.cpp
+++ b/tests_client/timer/test_timer.cpp
@@ -27,12 +27,12 @@ int main(int argc, char **argv) {
   ladder::Timer *timer = new ladder::Timer(ladder::EventLoopPtr(&loop));
   ladder::Timer *timer1 = new ladder::Timer(ladder::EventLoopPtr(&loop));
 #endif
-  timer->set_timer_event_callback(std::bind(PrintTick, &tick_));
-  timer1->set_timer_event_callback(std::bind(PrintTick1, &tick1_));
+  timer->SetTimmerEventCallback(std::bind(PrintTick, &tick_));
+  timer1->SetTimmerEventCallback(std::bind(PrintTick1, &tick1_));
 #ifndef LADDER_OS_FREEBSD
-  timer->set_interval(1000000);  // triggered once
+  timer->SetInterval(1000000);  // triggered once
 #endif
-  timer1->set_interval(1000000, true);  // triggered periodically
+  timer1->SetInterval(1000000, true);  // triggered periodically
 #ifdef LADDER_OS_WINDOWS
   while (1)
     ;


### PR DESCRIPTION
example:
```
set_read_callback() -> SetReadCallback()
set_connection_callback() -> SetConnectionCallback()
```